### PR TITLE
Update setup and execute methods in guide (#1288636)

### DIFF
--- a/en-US/Anaconda_Addon_Development_Guide.xml
+++ b/en-US/Anaconda_Addon_Development_Guide.xml
@@ -776,7 +776,7 @@ HELLO_FILE_PATH = "/root/hello_world_addon_output.txt"</programlisting>
       </para>
       <example id="exam-kickstart-setup-execute">
         <title>Using the setup and execute Methods</title>
-        <programlisting language="Python">    def setup(self, storage, ksdata, instclass):
+        <programlisting language="Python">    def setup(self, storage, ksdata, instclass, payload):
         """
         The setup method that should make changes to the runtime environment
         according to the data stored in this object.
@@ -789,13 +789,16 @@ HELLO_FILE_PATH = "/root/hello_world_addon_output.txt"</programlisting>
         :type ksdata: pykickstart.base.BaseHandler instance
         :param instclass: distribution-specific information
         :type instclass: pyanaconda.installclass.BaseInstallClass
+        :param payload: object managing packages and environment groups
+                        for the installation
+        :type payload: pyanaconda.packaging.dnfpayload.DNFPayload
 
         """
 
         # no actions needed in this addon
         pass
 
-    def execute(self, storage, ksdata, instclass, users):
+    def execute(self, storage, ksdata, instclass, users, payload):
         """
         The execute method that should make changes to the installed system. It
         is called only once in the post-install setup phase.

--- a/en-US/Revision_History.xml
+++ b/en-US/Revision_History.xml
@@ -8,6 +8,20 @@
   <simpara>
     <revhistory>
       <revision>
+        <revnumber>2-1</revnumber>
+        <date>Fri Apr 29 2016</date>
+        <author>
+          <firstname>Jiří</firstname>
+          <surname>Konečný</surname>
+          <email>jkonecny@redhat.com</email>
+        </author>
+        <revdescription>
+          <simplelist>
+            <member>Payload object was added to setup and execute methods. Change this guide to reflect the current state.</member>
+          </simplelist>
+        </revdescription>
+      </revision>
+      <revision>
         <revnumber>2-0</revnumber>
         <date>Fri Jul 03 2015</date>
         <author>


### PR DESCRIPTION
Setup and execute methods can now use payload object.
Update this documentation to reflect present state.

*Related: rhbz#1288636*