### PR TITLE
Replace old mailing list with a new Fedora one

### DIFF
--- a/en-US/Anaconda_Addon_Development_Guide.xml
+++ b/en-US/Anaconda_Addon_Development_Guide.xml
@@ -1880,7 +1880,7 @@ test:
       Members of the <application>Anaconda</application> development team (and in particular
       Vratislav Podzimek) are always willing to help add-on developers with their questions and
       issues. The best place to ask for help is the <ulink
-        url="https://www.redhat.com/mailman/listinfo/anaconda-devel-list">anaconda-devel</ulink>
+        url="https://lists.fedoraproject.org/archives/list/anaconda-devel@lists.fedoraproject.org/">anaconda-devel</ulink>
       mailing list that is read and moderated by the <application>Anaconda</application> developers.
     </para>
     <indexterm>


### PR DESCRIPTION
We are migrating anaconda-devel list under Fedora.